### PR TITLE
Handle missing "code" key in JSON reports

### DIFF
--- a/src/main/java/hudson/plugins/brakeman/scanners/BrakemanJSONScanner.java
+++ b/src/main/java/hudson/plugins/brakeman/scanners/BrakemanJSONScanner.java
@@ -55,10 +55,15 @@ public class BrakemanJSONScanner extends AbstractBrakemanScanner {
             String type = row.getString("warning_type");
             String category = getCategory(filterType).getName();
             StringBuilder message = new StringBuilder();
-            message.
-                append(row.getString("message")).
+            message.append(row.getString("message"));
+
+            if(row.has("code")) {
+              String code = row.getString("code");
+              message.
                 append(": ").
                 append(row.getString("code"));
+            }
+
             Priority priority = checkPriority(row.getString("confidence"));
 
             project.addAnnotation(new Warning(fileName, getStart(line), getEnd(line), type, category, message.toString(), priority));


### PR DESCRIPTION
Not all warnings have a "code" entry in the JSON report.