### PR TITLE
Treat "info" level warnings as "low"

### DIFF
--- a/src/main/java/hudson/plugins/brakeman/scanners/AbstractBrakemanScanner.java
+++ b/src/main/java/hudson/plugins/brakeman/scanners/AbstractBrakemanScanner.java
@@ -34,7 +34,7 @@ public abstract class AbstractBrakemanScanner {
             prio = Priority.NORMAL;
         } else if ("High".equalsIgnoreCase(priority)) {
             prio =  Priority.HIGH;
-        } else if ("Weak".equalsIgnoreCase(priority)) {
+        } else if ("Weak".equalsIgnoreCase(priority) || "Info".equalsIgnoreCase(priority)) {
             prio =  Priority.LOW;
         }
         return prio;

--- a/src/main/java/hudson/plugins/brakeman/scanners/BrakemanTabsScanner.java
+++ b/src/main/java/hudson/plugins/brakeman/scanners/BrakemanTabsScanner.java
@@ -20,7 +20,7 @@ public class BrakemanTabsScanner extends AbstractBrakemanScanner {
 
     private boolean result;
 
-    private static Pattern pattern = Pattern.compile("^([^\t]+?)\t(\\d+)\t([\\w\\s]+?)\t(\\w+)\t([^\t]+?)\t(High|Medium|Weak)", Pattern.MULTILINE);
+    private static Pattern pattern = Pattern.compile("^([^\t]+?)\t(\\d+)\t([\\w\\s]+?)\t(\\w+)\t([^\t]+?)\t(High|Medium|Weak|Info)", Pattern.MULTILINE);
     /**
      * Creates a new instance of <code>BrakemanTabsScanner</code>
      */


### PR DESCRIPTION
Brakeman Pro generates "informational" level warnings but the static analysis utils plugin only supports High/Medium/Low.